### PR TITLE
Improve iOS style

### DIFF
--- a/character_chat_page.dart
+++ b/character_chat_page.dart
@@ -338,7 +338,7 @@ class _CharacterChatPageState extends State<CharacterChatPage> {
   void _showMessageOptions(BuildContext context, Message message) {
     showModalBottomSheet(
       context: context,
-      backgroundColor: const Color(0xFFF7F7F7),
+      backgroundColor: Colors.white,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
       ),
@@ -414,7 +414,7 @@ class _CharacterChatPageState extends State<CharacterChatPage> {
             ),
           ],
         ),
-        backgroundColor: const Color(0xFFF7F7F7),
+        backgroundColor: Colors.white,
         elevation: 0,
         actions: [
           if (_awaitingReply)
@@ -468,6 +468,7 @@ class _CharacterChatPageState extends State<CharacterChatPage> {
           Expanded(
             child: ListView.builder(
               controller: _scroll,
+              physics: const BouncingScrollPhysics(),
               padding: const EdgeInsets.all(16),
               itemCount: _messages.length,
               itemBuilder: (context, index) {
@@ -580,6 +581,7 @@ class _CharacterChatPageState extends State<CharacterChatPage> {
               padding: const EdgeInsets.symmetric(horizontal: 16),
               child: ListView.builder(
                 scrollDirection: Axis.horizontal,
+                physics: const BouncingScrollPhysics(),
                 itemCount: _characterPrompts.length,
                 itemBuilder: (context, index) {
                   return Container(
@@ -602,7 +604,7 @@ class _CharacterChatPageState extends State<CharacterChatPage> {
           Container(
             padding: const EdgeInsets.all(16),
             decoration: BoxDecoration(
-              color: const Color(0xFFF7F7F7),
+              color: Colors.white,
               border: Border(top: BorderSide(color: Colors.grey.shade200)),
             ),
             child: Row(
@@ -658,7 +660,7 @@ class _CharacterChatPageState extends State<CharacterChatPage> {
       builder: (context) => Container(
         height: MediaQuery.of(context).size.height * 0.7,
         decoration: const BoxDecoration(
-          color: Color(0xFFF7F7F7),
+          color: Colors.white,
           borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
         ),
         child: Column(
@@ -729,6 +731,7 @@ class _CharacterChatPageState extends State<CharacterChatPage> {
                           border: Border.all(color: Colors.grey.shade200),
                         ),
                         child: SingleChildScrollView(
+                          physics: const BouncingScrollPhysics(),
                           child: Text(
                             widget.character.systemPrompt,
                             style: GoogleFonts.poppins(fontSize: 14),

--- a/character_editor.dart
+++ b/character_editor.dart
@@ -132,7 +132,7 @@ class _CharacterEditorState extends State<CharacterEditor> {
       builder: (context) => Container(
         height: MediaQuery.of(context).size.height * 0.7,
         decoration: const BoxDecoration(
-          color: Color(0xFFF7F7F7),
+          color: Colors.white,
           borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
         ),
         child: Column(
@@ -161,6 +161,7 @@ class _CharacterEditorState extends State<CharacterEditor> {
             Expanded(
               child: ListView.builder(
                 padding: const EdgeInsets.symmetric(horizontal: 16),
+                physics: const BouncingScrollPhysics(),
                 itemCount: _promptTemplates.length,
                 itemBuilder: (context, index) {
                   final template = _promptTemplates[index];
@@ -263,7 +264,7 @@ class _CharacterEditorState extends State<CharacterEditor> {
           isEditing ? 'Edit Character' : 'Create Character',
           style: GoogleFonts.poppins(fontWeight: FontWeight.bold),
         ),
-        backgroundColor: const Color(0xFFF7F7F7),
+        backgroundColor: Colors.white,
         elevation: 0,
         actions: [
           if (isEditing && !widget.character!.isBuiltIn)
@@ -294,6 +295,7 @@ class _CharacterEditorState extends State<CharacterEditor> {
       body: Form(
         key: _formKey,
         child: SingleChildScrollView(
+          physics: const BouncingScrollPhysics(),
           padding: const EdgeInsets.all(16),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -586,7 +588,7 @@ class _CharacterEditorState extends State<CharacterEditor> {
       builder: (context) => Container(
         height: 300,
         decoration: const BoxDecoration(
-          color: Color(0xFFF7F7F7),
+          color: Colors.white,
           borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
         ),
         child: Column(

--- a/characters_page.dart
+++ b/characters_page.dart
@@ -128,12 +128,13 @@ class _CharactersPageState extends State<CharactersPage> with TickerProviderStat
       body: FadeTransition(
         opacity: _fadeAnimation,
         child: CustomScrollView(
+          physics: const BouncingScrollPhysics(),
           slivers: [
             SliverAppBar(
               expandedHeight: 120,
               floating: false,
               pinned: true,
-              backgroundColor: const Color(0xFFF7F7F7),
+              backgroundColor: Colors.white,
               elevation: 0,
               flexibleSpace: FlexibleSpaceBar(
                 title: Text(
@@ -263,7 +264,7 @@ class _CharactersPageState extends State<CharactersPage> with TickerProviderStat
       backgroundColor: Colors.transparent,
       builder: (context) => Container(
         decoration: const BoxDecoration(
-          color: Color(0xFFF7F7F7),
+          color: Colors.white,
           borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
         ),
         child: SafeArea(

--- a/chat_page.dart
+++ b/chat_page.dart
@@ -118,7 +118,7 @@ class ChatPageState extends State<ChatPage> {
   void _showUserMessageOptions(BuildContext context, Message message) {
     showModalBottomSheet(
       context: context,
-      backgroundColor: const Color(0xFFF7F7F7),
+      backgroundColor: Colors.white,
       shape: const RoundedRectangleBorder(borderRadius: BorderRadius.vertical(top: Radius.circular(20))),
       builder: (context) {
         return Wrap(
@@ -341,6 +341,7 @@ class ChatPageState extends State<ChatPage> {
         Expanded(
           child: ListView.builder(
             controller: _scroll,
+            physics: const BouncingScrollPhysics(),
             padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
             itemCount: _messages.length,
             itemBuilder: (_, index) {
@@ -359,6 +360,7 @@ class ChatPageState extends State<ChatPage> {
             padding: const EdgeInsets.fromLTRB(20, 0, 20, 12),
             child: SingleChildScrollView(
               scrollDirection: Axis.horizontal,
+              physics: const BouncingScrollPhysics(),
               child: Row(
                 children: _prompts.map((p) => Padding(
                           padding: const EdgeInsets.only(right: 8),
@@ -544,7 +546,7 @@ class _InputBar extends StatelessWidget {
           Container(
             margin: const EdgeInsets.fromLTRB(20, 0, 20, 12),
             decoration: BoxDecoration(
-              color: const Color(0xFFF7F7F7),
+              color: Colors.white,
               borderRadius: BorderRadius.circular(32),
               boxShadow: [BoxShadow(color: Colors.black.withOpacity(0.05), blurRadius: 20, offset: const Offset(0, 4))],
             ),

--- a/file_upload_widget.dart
+++ b/file_upload_widget.dart
@@ -168,6 +168,7 @@ class _FileUploadWidgetState extends State<FileUploadWidget> {
                 Expanded(
                   child: ListView.builder(
                     padding: const EdgeInsets.symmetric(horizontal: 20),
+                    physics: const BouncingScrollPhysics(),
                     itemCount: _fileService.uploadedFiles.length,
                     itemBuilder: (context, index) {
                       final file = _fileService.uploadedFiles[index];

--- a/file_viewer_page.dart
+++ b/file_viewer_page.dart
@@ -121,6 +121,7 @@ class FileViewerPage extends StatelessWidget {
                         file.type == FileType.gif
                     ? Image.memory(file.bytes, fit: BoxFit.contain)
                     : SingleChildScrollView(
+                        physics: const BouncingScrollPhysics(),
                         padding: const EdgeInsets.all(16),
                         child: SelectableText(
                           file.content,

--- a/ios_page_transitions.dart
+++ b/ios_page_transitions.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+/// Simple slide transition that mimics iOS push animation without using
+/// Cupertino widgets.
+class IOSPageTransitionsBuilder extends PageTransitionsBuilder {
+  const IOSPageTransitionsBuilder();
+
+  @override
+  Widget buildTransitions<T>(
+    PageRoute<T> route,
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    return SlideTransition(
+      position: Tween<Offset>(
+        begin: const Offset(1.0, 0.0),
+        end: Offset.zero,
+      ).animate(CurvedAnimation(
+        parent: animation,
+        curve: Curves.easeOutCubic,
+      )),
+      child: child,
+    );
+  }
+}

--- a/main.dart
+++ b/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import 'ios_page_transitions.dart';
+
 import 'auth_and_profile_pages.dart';
 import 'auth_service.dart';
 
@@ -10,7 +12,7 @@ void main() {
   AuthService(); 
   
   SystemChrome.setSystemUIOverlayStyle(const SystemUiOverlayStyle(
-    systemNavigationBarColor: Color(0xFFF7F7F7),
+    systemNavigationBarColor: Colors.white,
     statusBarColor: Colors.transparent,
     systemNavigationBarIconBrightness: Brightness.dark,
     statusBarIconBrightness: Brightness.dark,
@@ -25,15 +27,27 @@ class AhamAIApp extends StatelessWidget {
     return MaterialApp(
       title: 'AhamAI',
       debugShowCheckedModeBanner: false,
+      scrollBehavior: const MaterialScrollBehavior().copyWith(
+        physics: const BouncingScrollPhysics(),
+      ),
       theme: ThemeData(
         useMaterial3: true,
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: Colors.grey,
-          brightness: Brightness.light,
+        colorScheme: const ColorScheme.light(),
+        scaffoldBackgroundColor: Colors.white,
+        splashFactory: NoSplash.splashFactory,
+        highlightColor: Colors.transparent,
+        pageTransitionsTheme: const PageTransitionsTheme(
+          builders: {
+            TargetPlatform.android: IOSPageTransitionsBuilder(),
+            TargetPlatform.iOS: IOSPageTransitionsBuilder(),
+            TargetPlatform.linux: IOSPageTransitionsBuilder(),
+            TargetPlatform.macOS: IOSPageTransitionsBuilder(),
+            TargetPlatform.windows: IOSPageTransitionsBuilder(),
+          },
         ),
-        scaffoldBackgroundColor: const Color(0xFFF7F7F7),
         appBarTheme: const AppBarTheme(
-          backgroundColor: Color(0xFFF7F7F7),
+          backgroundColor: Colors.white,
+          foregroundColor: Colors.black,
           elevation: 0,
           scrolledUnderElevation: 0,
         ),

--- a/main_shell.dart
+++ b/main_shell.dart
@@ -71,7 +71,7 @@ class _MainShellState extends State<MainShell> {
   void _showModelSelectionSheet() {
     showModalBottomSheet(
       context: context,
-      backgroundColor: const Color(0xFFF7F7F7),
+      backgroundColor: Colors.white,
       shape: const RoundedRectangleBorder(borderRadius: BorderRadius.vertical(top: Radius.circular(20))),
       builder: (context) {
         return SafeArea(
@@ -241,7 +241,7 @@ class _MainShellState extends State<MainShell> {
               ),
         ),
         child: BottomNavigationBar(
-          backgroundColor: const Color(0xFFF7F7F7),
+          backgroundColor: Colors.white,
           elevation: 0,
           items: <BottomNavigationBarItem>[
             BottomNavigationBarItem(icon: _buildAnimatedIcon(Icons.home_filled, Icons.home_outlined, 0), label: 'Home'),

--- a/saved_page.dart
+++ b/saved_page.dart
@@ -42,7 +42,7 @@ class _SavedPageState extends State<SavedPage> {
   Widget build(BuildContext context) {
     return Container(
       decoration: const BoxDecoration(
-        color: Color(0xFFF7F7F7),
+        color: Colors.white,
       ),
       child: Column(
         children: [
@@ -73,6 +73,7 @@ class _SavedPageState extends State<SavedPage> {
           Expanded(
             child: PageView(
               controller: _pageController,
+              physics: const BouncingScrollPhysics(),
               onPageChanged: (index) {
                 setState(() {
                   _selectedIndex = index;
@@ -189,6 +190,7 @@ class _ChatHistoryView extends StatelessWidget {
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 16),
       child: ListView.builder(
+        physics: const BouncingScrollPhysics(),
         padding: EdgeInsets.only(
           top: 8,
           bottom: kBottomNavigationBarHeight + 80,
@@ -275,6 +277,7 @@ class _SavedRepliesView extends StatelessWidget {
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 16),
       child: ListView.builder(
+        physics: const BouncingScrollPhysics(),
         padding: EdgeInsets.only(
           top: 8,
           bottom: kBottomNavigationBarHeight + 80,


### PR DESCRIPTION
## Summary
- create `IOSPageTransitionsBuilder` for smooth sliding transitions
- use white theme and remove ripple effects
- enable global bouncing scroll physics and add it to lists
- adjust bottom navigation and modal backgrounds

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687a6b40a2808332a24c5d993476376c